### PR TITLE
Bumped doctrine/persistence to ^2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
         "php": "^7.2 || ^8.0",
         "symfony/http-foundation": "^3.4|^4.2|^5.0",
         "myclabs/deep-copy": "^1.9",
-        "doctrine/persistence": "^1.1"
+        "doctrine/persistence": "^2.1"
     }
 }

--- a/src/DeepCopy/Filter/DoctrineEntityTypeFilter.php
+++ b/src/DeepCopy/Filter/DoctrineEntityTypeFilter.php
@@ -6,8 +6,8 @@ use Aeviiq\StorageManager\Exception\LogicException;
 use Aeviiq\StorageManager\StorableEntity;
 use DeepCopy\Reflection\ReflectionHelper;
 use DeepCopy\TypeFilter\TypeFilter;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Proxy;
 
 final class DoctrineEntityTypeFilter implements TypeFilter
 {

--- a/src/DeepCopy/Filter/StorableEntityTypeFilter.php
+++ b/src/DeepCopy/Filter/StorableEntityTypeFilter.php
@@ -5,7 +5,7 @@ namespace Aeviiq\StorageManager\DeepCopy\Filter;
 use Aeviiq\StorageManager\Exception\UnexpectedValueException;
 use Aeviiq\StorageManager\StorableEntity;
 use DeepCopy\TypeFilter\TypeFilter;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 final class StorableEntityTypeFilter implements TypeFilter
 {

--- a/src/DeepCopy/Matcher/DoctrineEntityTypeMatcher.php
+++ b/src/DeepCopy/Matcher/DoctrineEntityTypeMatcher.php
@@ -3,8 +3,8 @@
 namespace Aeviiq\StorageManager\DeepCopy\Matcher;
 
 use DeepCopy\TypeMatcher\TypeMatcher;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Proxy;
 
 final class DoctrineEntityTypeMatcher extends TypeMatcher
 {

--- a/src/StorageManager.php
+++ b/src/StorageManager.php
@@ -8,8 +8,8 @@ use Aeviiq\StorageManager\DeepCopy\Matcher\DoctrineEntityTypeMatcher;
 use Aeviiq\StorageManager\DeepCopy\Matcher\StorableEntityTypeMatcher;
 use Aeviiq\StorageManager\Store\StoreInterface;
 use DeepCopy\DeepCopy;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Proxy;
 
 final class StorageManager implements StorageManagerInterface
 {


### PR DESCRIPTION
Bumped doctrine/persistence to ^2.1, and replaced the old namespaces …for the ObjectManager and Proxy for the new ones.

Fixes #17 